### PR TITLE
Fixes issue #16 (multiple Set-Cookie headers)

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,7 +9,7 @@ var path = require('path');
 var fs = require('fs');
 var shell = require('shelljs');
 
-var PHP_CGI = shell.which('php-cgi');
+var PHP_CGI = shell.which('php-cgi').toString();
 
 if (!PHP_CGI) {
   throw new Error('"php-cgi" cannot be found');
@@ -189,6 +189,10 @@ function runPHP(req, response, next, url, file) {
           // console.log('HEADER: '+m[0]+': '+m[1]);
           if (m[0] == 'Status') {
             response.statusCode = parseInt(m[1]);
+          }
+				  if (m[0] == 'Set-Cookie') {
+				    var prevCookies = response.getHeader('Set-Cookie');
+				    m[1] = prevCookies ? [prevCookies, m[1]] : m[1];
           }
           if (m.length == 2) {
             response.setHeader(m[0], m[1]);

--- a/main.js
+++ b/main.js
@@ -190,9 +190,9 @@ function runPHP(req, response, next, url, file) {
           if (m[0] == 'Status') {
             response.statusCode = parseInt(m[1]);
           }
-				  if (m[0] == 'Set-Cookie') {
-				    var prevCookies = response.getHeader('Set-Cookie');
-				    m[1] = prevCookies ? [prevCookies, m[1]] : m[1];
+          if (m[0] == 'Set-Cookie') {
+            var prevCookies = response.getHeader('Set-Cookie');
+            m[1] = prevCookies ? [prevCookies, m[1]] : m[1];
           }
           if (m.length == 2) {
             response.setHeader(m[0], m[1]);

--- a/main.js
+++ b/main.js
@@ -190,10 +190,10 @@ function runPHP(req, response, next, url, file) {
           if (m[0] == 'Status') {
             response.statusCode = parseInt(m[1]);
           }
-          if (m[0] == "Set-Cookie") {
-            var prevCookies = response.getHeader("Set-Cookie");
+          if (m[0] == 'Set-Cookie') {
+            var prevCookies = response.getHeader('Set-Cookie');
             if (prevCookies) {
-              if (typeof prevCookies == "string") {
+              if (typeof prevCookies == 'string') {
                 m[1] = [prevCookies, m[1]];
               } else {
                 prevCookies.push(m[1]);

--- a/main.js
+++ b/main.js
@@ -190,9 +190,16 @@ function runPHP(req, response, next, url, file) {
           if (m[0] == 'Status') {
             response.statusCode = parseInt(m[1]);
           }
-          if (m[0] == 'Set-Cookie') {
-            var prevCookies = response.getHeader('Set-Cookie');
-            m[1] = prevCookies ? [prevCookies, m[1]] : m[1];
+          if (m[0] == "Set-Cookie") {
+            var prevCookies = response.getHeader("Set-Cookie");
+            if (prevCookies) {
+              if (typeof prevCookies == "string") {
+                m[1] = [prevCookies, m[1]];
+              } else {
+                prevCookies.push(m[1]);
+                m[1] = prevCookies;
+              }
+            }
           }
           if (m.length == 2) {
             response.setHeader(m[0], m[1]);

--- a/main.js
+++ b/main.js
@@ -9,7 +9,7 @@ var path = require('path');
 var fs = require('fs');
 var shell = require('shelljs');
 
-var PHP_CGI = shell.which('php-cgi').toString();
+var PHP_CGI = shell.which('php-cgi');
 
 if (!PHP_CGI) {
   throw new Error('"php-cgi" cannot be found');
@@ -150,7 +150,7 @@ function runPHP(req, response, next, url, file) {
   if (/.*?\.php$/.test(file)) {
     var res = '', err = '';
 
-    var php = child.spawn(PHP_CGI, [], {
+    var php = child.spawn(PHP_CGI.toString(), [], {
       env: env
     });
 


### PR DESCRIPTION
Confirmed issue that setting multiple headers via php's `setcookie()` method over-writes the Set-Cookie header each time, resulting in the last cookie to be the only one sent to the client.

**Solved by appending each cookie to the Set-Cookie header, instead of overwriting it.**

Also added `.toString()` to line 153 to prevent `child.spawn()` from throwing a type-error, because `shell.which()` results in an object, not a string. And the first parameter to `spawn()` must be a string.